### PR TITLE
Fix Sonar report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,3 +22,20 @@ plugins {
 
 group = "net.thauvin.erik"
 version = "1.4.0-SNAPSHOT"
+
+dependencies {
+    kover(projects.lib)
+    kover(projects.app)
+}
+
+sonar {
+    properties {
+        property("sonar.projectName", rootProject.name)
+        property("sonar.projectKey", "ethauvin_${rootProject.name}")
+        property("sonar.organization", "ethauvin-github")
+        property("sonar.host.url", "https://sonarcloud.io")
+        property("sonar.sourceEncoding", "UTF-8")
+        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/kover/report.xml")
+        property("sonar.log.level", "DEBUG")
+    }
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-jvm.gradle.kts
@@ -42,4 +42,6 @@ tasks.withType<Test>().configureEach {
         exceptionFormat = TestExceptionFormat.FULL
         events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
     }
+
+    finalizedBy(tasks.matching { it.name == "koverXmlReport" })
 }

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/sonarqube.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/sonarqube.gradle.kts
@@ -33,21 +33,8 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-sonar {
-    properties {
-        property("sonar.projectName", rootProject.name)
-        property("sonar.projectKey", "ethauvin_${rootProject.name}")
-        property("sonar.organization", "ethauvin-github")
-        property("sonar.host.url", "https://sonarcloud.io")
-        property("sonar.sourceEncoding", "UTF-8")
-        property("sonar.sources", files("src/main/kotlin"))
-        property("sonar.test", files("src/test/kotlin"))
-        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/kover/report.xml")
-        property("sonar.log.level", "DEBUG")
-    }
-}
-
 tasks.withType<SonarTask>().configureEach {
+    dependsOn(tasks.withType<Test>())
     // workaround for https://github.com/Kotlin/kotlinx-kover/issues/394
     dependsOn(tasks.matching { it.name == "koverXmlReport" })
 }


### PR DESCRIPTION
* configure Sonar only on the root project (the Sonar plugin aggregates all of the properties from all subprojects, so defining them per subproject isn't necessary)
* aggregate the Kover reports (hopefully this helps Sonar find the coverage report?)
* and always generate Kover XML coverage reports after tests 