### PR TITLE
update Gradle Build workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,22 +1,34 @@
 name: gradle-ci
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    env:
-      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m"
-
     strategy:
       matrix:
         java-version: [ 11, 17, 20 ]
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m"
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
@@ -24,10 +36,19 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Cache Kotlin Konan
+        id: cache-kotlin-konan
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.konan/**/*
+          key: kotlin-konan-${{ runner.os }}
 
       - name: Test with Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-home-cache-cleanup: true
           arguments: build check --stacktrace -PtestsBadgeApiKey=${{ secrets.TESTS_BADGE_API_KEY }}


### PR DESCRIPTION
This PR updates the Gradle Build GitHub Workflow

* cache the Kotlin Native Konan dependencies, so the build runs faster
* only trigger the build for pushes/PRs that target the master branch (you can revert this change if you like?)
* adds [concurrency cancellation](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency), so if multiple commits are pushed in quick succession they don't clog up the actions
* Adds all OSes to the build workflow

The workflow is based on the [Fleks workflow](https://github.com/Quillraven/Fleks/blob/d363c57d72602d71688f99d9c78b44724421dd1f/.github/workflows/build.yml), which is also a Kotlin Multiplatform project.