### PR TITLE
add Java tests for verifying `@JvmStatic`

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-base.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     targets.withType<KotlinJvmTarget>().configureEach {
         testRuns.configureEach {
             executionTask.configure {
-                // useJUnitPlatform()
+                 useJUnitPlatform()
             }
         }
     }

--- a/urlencoder-lib/src/commonTest/kotlin/net/thauvin/erik/urlencoder/TestData.kt
+++ b/urlencoder-lib/src/commonTest/kotlin/net/thauvin/erik/urlencoder/TestData.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2001-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.thauvin.erik.urlencoder
+
+import kotlin.jvm.JvmField
+
+const val standardContent = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-_."
+
+val invalidContent = listOf("sdkjfh%", "sdkjfh%6", "sdkjfh%xx", "sdfjfh%-1")
+
+/**
+ * List of unencoded content paired with the encoded content.
+ */
+val decodedToEncoded = listOf(
+  TestData("a test &", "a%20test%20%26"),
+  TestData(
+    "!abcdefghijklmnopqrstuvwxyz%%ABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-_.~=",
+    "%21abcdefghijklmnopqrstuvwxyz%25%25ABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-_.%7E%3D"
+  ),
+  TestData("%#okékÉȢ smile!😁", "%25%23ok%C3%A9k%C3%89%C8%A2%20smile%21%F0%9F%98%81"),
+  TestData("\uD808\uDC00\uD809\uDD00\uD808\uDF00\uD808\uDD00", "%F0%92%80%80%F0%92%94%80%F0%92%8C%80%F0%92%84%80"),
+)
+
+data class TestData(
+  @JvmField
+  val unencoded: String,
+  @JvmField
+  val encoded: String,
+)

--- a/urlencoder-lib/src/commonTest/kotlin/net/thauvin/erik/urlencoder/UrlEncoderUtilTest.kt
+++ b/urlencoder-lib/src/commonTest/kotlin/net/thauvin/erik/urlencoder/UrlEncoderUtilTest.kt
@@ -23,30 +23,17 @@ import kotlin.test.DefaultAsserter.assertEquals
 import kotlin.test.DefaultAsserter.assertSame
 
 class UrlEncoderUtilTest {
-    private val same = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-_."
-
-    companion object {
-        val invalid = listOf("sdkjfh%", "sdkjfh%6", "sdkjfh%xx", "sdfjfh%-1")
-
-        val validMap = listOf(
-            "a test &" to "a%20test%20%26",
-            "!abcdefghijklmnopqrstuvwxyz%%ABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-_.~=" to
-                    "%21abcdefghijklmnopqrstuvwxyz%25%25ABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-_.%7E%3D",
-            "%#okékÉȢ smile!😁" to "%25%23ok%C3%A9k%C3%89%C8%A2%20smile%21%F0%9F%98%81",
-            "\uD808\uDC00\uD809\uDD00\uD808\uDF00\uD808\uDD00" to "%F0%92%80%80%F0%92%94%80%F0%92%8C%80%F0%92%84%80",
-        )
-    }
 
     @Test
     fun decodeURL() {
-        for (m in validMap) {
-            assertEquals(m.first, decode(m.second))
+        for ((unencoded, encoded) in decodedToEncoded) {
+            assertEquals(unencoded, decode(encoded))
         }
     }
 
     @Test
     fun decodeWithException() {
-        for (source in invalid) {
+        for (source in invalidContent) {
             assertFailsWith<IllegalArgumentException>(
                 message = "decode($source)",
                 block = { decode(source) }
@@ -56,7 +43,7 @@ class UrlEncoderUtilTest {
 
     @Test
     fun decodeWhenNoneNeeded() {
-        assertSame(same, decode(same))
+        assertSame(standardContent, decode(standardContent))
         assertEquals("decode('')", decode(""), "")
         assertEquals("decode(' ')", decode(" "), " ")
     }
@@ -72,8 +59,8 @@ class UrlEncoderUtilTest {
 
     @Test
     fun encodeURL() {
-        for (m in validMap) {
-            assertEquals(m.second, encode(m.first))
+        for ((unencoded, encoded) in decodedToEncoded) {
+            assertEquals(encoded, encode(unencoded))
         }
     }
 
@@ -86,8 +73,8 @@ class UrlEncoderUtilTest {
 
     @Test
     fun encodeWhenNoneNeeded() {
-        assertSame(encode(same), same)
-        assertSame("with empty allow", encode(same, allow = ""), same)
+        assertSame(encode(standardContent), standardContent)
+        assertSame("with empty allow", encode(standardContent, allow = ""), standardContent)
     }
 
     @Test

--- a/urlencoder-lib/src/jvmTest/java/net/thauvin/erik/urlencoder/UrlEncoderJavaTest.java
+++ b/urlencoder-lib/src/jvmTest/java/net/thauvin/erik/urlencoder/UrlEncoderJavaTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2001-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.thauvin.erik.urlencoder;
+
+import org.junit.jupiter.api.Test;
+
+import static net.thauvin.erik.urlencoder.TestDataKt.getDecodedToEncoded;
+import static net.thauvin.erik.urlencoder.UrlEncoderUtil.decode;
+import static net.thauvin.erik.urlencoder.UrlEncoderUtil.encode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UrlEncoderJavaTest {
+
+    @Test
+    public void decodeURL() {
+        assertAll(
+                getDecodedToEncoded()
+                        .stream()
+                        .map(data ->
+                                () -> assertEquals(data.unencoded, decode(data.encoded))
+                        )
+        );
+    }
+
+    @Test
+    public void encodeURL() {
+        assertAll(
+                getDecodedToEncoded()
+                        .stream()
+                        .map(data ->
+                                () -> assertEquals(data.encoded, encode(data.unencoded))
+                        )
+        );
+    }
+}


### PR DESCRIPTION
* Created some Java tests to verify that the library can be called from Java code
* moved test data to a separate class so it's easier to re-use in the Java tests, and created a TestData class so it's easier to use in Java (IntelliJ didn't like the Pair class for some reason, and kept showing errors for `data.getFirst()`)
* Enabled JUnitPlatform (otherwise the JUnit classes weren't available in the jvmTest source set)

Related to #12 