### PR TITLE
bump Kotlin to 1.9.23, enable additional Kotlin Multiplatform targets

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,6 +6,6 @@ dependencies {
     implementation("com.github.ben-manes:gradle-versions-plugin:0.51.0")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.1")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
     implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.7.4")
 }

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-base.gradle.kts
@@ -3,7 +3,9 @@ package buildsrc.conventions.lang
 import buildsrc.utils.Rife2TestListener
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -23,29 +25,20 @@ plugins {
 
 kotlin {
     //jvmToolchain(11)
+
     applyDefaultHierarchyTemplate()
 
-    targets.configureEach {
-        compilations.configureEach {
-            kotlinOptions {
-                languageVersion = "1.6"
-            }
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        languageVersion = KotlinVersion.KOTLIN_1_6
     }
 
     // configure all Kotlin/JVM Tests to use JUnit
     targets.withType<KotlinJvmTarget>().configureEach {
         testRuns.configureEach {
             executionTask.configure {
-                 useJUnitPlatform()
+                useJUnitPlatform()
             }
-        }
-    }
-
-    sourceSets.configureEach {
-        languageSettings {
-            // languageVersion =
-            // apiVersion =
         }
     }
 }

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-base.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 kotlin {
     //jvmToolchain(11)
+    applyDefaultHierarchyTemplate()
 
     targets.configureEach {
         compilations.configureEach {

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-js.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-js.gradle.kts
@@ -1,5 +1,7 @@
 package buildsrc.conventions.lang
 
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+
 /** conventions for a Kotlin/JS subproject */
 
 plugins {
@@ -7,12 +9,38 @@ plugins {
 }
 
 kotlin {
-    targets {
-        js(IR) {
-            browser()
-            nodejs()
-        }
+    js(IR) {
+        browser()
+        nodejs()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        nodejs()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
     }
 }
 
 relocateKotlinJsStore()
+
+
+//region FIXME: WORKAROUND https://youtrack.jetbrains.com/issue/KT-65864
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
+    rootProject.extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
+        // Use a Node.js version current enough to support Kotlin/Wasm
+        nodeVersion = "22.0.0-nightly2024010568c8472ed9"
+        logger.lifecycle("Using Node.js $nodeVersion to support Kotlin/Wasm")
+        nodeDownloadBaseUrl = "https://nodejs.org/download/nightly"
+    }
+}
+
+rootProject.tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
+    // Prevent Yarn from complaining about newer Node.js versions.
+    args.add("--ignore-engines")
+}
+//endregion

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-native.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-native.gradle.kts
@@ -7,94 +7,26 @@ plugins {
 }
 
 kotlin {
-
-    // Native targets all extend commonMain and commonTest.
-    //
-    // Some targets (ios, tvos, watchos) are shortcuts provided by the Kotlin DSL, that
-    // provide additional targets, except for 'simulators' which must be defined manually.
-    // https://kotlinlang.org/docs/multiplatform-share-on-platforms.html#use-target-shortcuts
-    //
-    // common/
-    // └── native/
-    //     ├── linuxX64
-    //     ├── mingwX64
-    //     ├── macosX64
-    //     ├── macosArm64
-    //     ├── ios/ (shortcut)
-    //     │   ├── iosArm64
-    //     │   ├── iosX64
-    //     │   └── iosSimulatorArm64
-    //     ├── tvos/ (shortcut)
-    //     │   ├── tvosArm64
-    //     │   ├── tvosX64
-    //     │   └── tvosSimulatorArm64Main
-    //     └── watchos/ (shortcut)
-    //         ├── watchosArm32
-    //         ├── watchosArm64
-    //         ├── watchosX64
-    //         └── watchosSimulatorArm64Main
-
     linuxX64()
 
     mingwX64()
 
+    linuxArm64()
+
     macosX64()
     macosArm64()
 
-    // https://kotlinlang.org/docs/multiplatform-share-on-platforms.html#use-target-shortcuts
-    ios()     // iosArm64, iosX64
-    watchos() // watchosArm32, watchosArm64, watchosX64
-    tvos()    // tvosArm64, tvosX64
-
+    iosArm64()
+    iosX64()
     iosSimulatorArm64()
-    tvosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX64()
     watchosSimulatorArm64()
+    watchosDeviceArm64()
 
-    @Suppress("UNUSED_VARIABLE")
-    sourceSets {
-        val commonMain by getting {}
-        val commonTest by getting {}
-
-        val nativeMain by creating { dependsOn(commonMain) }
-        val nativeTest by creating { dependsOn(commonTest) }
-
-        // Linux
-        val linuxX64Main by getting { dependsOn(nativeMain) }
-        val linuxX64Test by getting { dependsOn(nativeTest) }
-
-        // Windows - MinGW
-        val mingwX64Main by getting { dependsOn(nativeMain) }
-        val mingwX64Test by getting { dependsOn(nativeTest) }
-
-        // Apple - macOS
-        val macosArm64Main by getting { dependsOn(nativeMain) }
-        val macosArm64Test by getting { dependsOn(nativeTest) }
-
-        val macosX64Main by getting { dependsOn(nativeMain) }
-        val macosX64Test by getting { dependsOn(nativeTest) }
-
-        // Apple - iOS
-        val iosMain by getting { dependsOn(nativeMain) }
-        val iosTest by getting { dependsOn(nativeTest) }
-
-        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
-        // val iosSimulatorArm64Test by getting { dependsOn(iosTest) }
-
-        // // Apple - tvOS
-        // val tvosMain by getting { dependsOn(nativeMain) }
-        // val tvosTest by getting { dependsOn(nativeTest) }
-
-        // val tvosSimulatorArm64Main by getting { dependsOn(tvosMain) }
-        // val tvosSimulatorArm64Test by getting { dependsOn(tvosTest) }
-
-        // // Apple - watchOS
-        // val watchosMain by getting { dependsOn(nativeMain) }
-        // val watchosTest by getting { dependsOn(nativeTest) }
-
-        // val watchosSimulatorArm64Main by getting { dependsOn(watchosMain) }
-        // val watchosSimulatorArm64Test by getting { dependsOn(watchosTest) }
-
-        // val iosArm32Main by getting { dependsOn(desktopMain) }
-        // val iosArm32Test by getting { dependsOn(nativeTest) }
-    }
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,82 +1,90 @@
 rootProject.name = "urlencoder"
 
 pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
 
-  repositories {
-    mavenCentral()
-    maven("https://oss.sonatype.org/content/repositories/snapshots") {
-      name = "Sonatype Snapshots"
-      mavenContent { snapshotsOnly() }
-    }
-
-    // Declare the Node.js & Yarn download repositories
-    exclusiveContent {
-      forRepository {
-        ivy("https://nodejs.org/dist/") {
-          name = "Node Distributions at $url"
-          patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
-          metadataSources { artifact() }
-          content { includeModule("org.nodejs", "node") }
+    repositories {
+        mavenCentral()
+        maven("https://oss.sonatype.org/content/repositories/snapshots") {
+            name = "Sonatype Snapshots"
+            mavenContent { snapshotsOnly() }
         }
-      }
-      filter { includeGroup("org.nodejs") }
-    }
 
-    exclusiveContent {
-      forRepository {
-        ivy("https://github.com/yarnpkg/yarn/releases/download") {
-          name = "Yarn Distributions at $url"
-          patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
-          metadataSources { artifact() }
-          content { includeModule("com.yarnpkg", "yarn") }
+        // Declare the Node.js & Yarn download repositories
+        exclusiveContent {
+            forRepositories(
+                ivy("https://nodejs.org/dist/") {
+                    name = "Node Distributions at $url"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
+                    metadataSources { artifact() }
+                },
+                ivy("https://nodejs.org/download/v8-canary/") {
+                    name = "Node Canary Distributions at $url"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
+                    metadataSources { artifact() }
+                },
+                ivy("https://nodejs.org/download/nightly/") {
+                    name = "Node Nightly Distributions at $url"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
+                    metadataSources { artifact() }
+                },
+            )
+            filter { includeGroup("org.nodejs") }
         }
-      }
-      filter { includeGroup("com.yarnpkg") }
-    }
 
-    // workaround for https://youtrack.jetbrains.com/issue/KT-51379
-    exclusiveContent {
-      forRepository {
-        ivy("https://download.jetbrains.com/kotlin/native/builds") {
-          name = "Kotlin Native"
-          patternLayout {
-            // example download URLs:
-            // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/linux-x86_64/kotlin-native-prebuilt-linux-x86_64-1.7.20.tar.gz
-            // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/windows-x86_64/kotlin-native-prebuilt-windows-x86_64-1.7.20.zip
-            // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/macos-x86_64/kotlin-native-prebuilt-macos-x86_64-1.7.20.tar.gz
-            listOf(
-              "macos-x86_64",
-              "macos-aarch64",
-              "osx-x86_64",
-              "osx-aarch64",
-              "linux-x86_64",
-              "windows-x86_64",
-            ).forEach { os ->
-              listOf("dev", "releases").forEach { stage ->
-                artifact("$stage/[revision]/$os/[artifact]-[revision].[ext]")
-              }
+        exclusiveContent {
+            forRepository {
+                ivy("https://github.com/yarnpkg/yarn/releases/download") {
+                    name = "Yarn Distributions at $url"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
+                    metadataSources { artifact() }
+                }
             }
-          }
-          metadataSources { artifact() }
+            filter { includeGroup("com.yarnpkg") }
         }
-      }
-      filter { includeModuleByRegex(".*", ".*kotlin-native-prebuilt.*") }
+
+        // workaround for https://youtrack.jetbrains.com/issue/KT-51379
+        exclusiveContent {
+            forRepository {
+                ivy("https://download.jetbrains.com/kotlin/native/builds") {
+                    name = "Kotlin Native"
+                    patternLayout {
+                        // example download URLs:
+                        // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/linux-x86_64/kotlin-native-prebuilt-linux-x86_64-1.7.20.tar.gz
+                        // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/windows-x86_64/kotlin-native-prebuilt-windows-x86_64-1.7.20.zip
+                        // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/macos-x86_64/kotlin-native-prebuilt-macos-x86_64-1.7.20.tar.gz
+                        listOf(
+                            "macos-x86_64",
+                            "macos-aarch64",
+                            "osx-x86_64",
+                            "osx-aarch64",
+                            "linux-x86_64",
+                            "windows-x86_64",
+                        ).forEach { os ->
+                            listOf("dev", "releases").forEach { stage ->
+                                artifact("$stage/[revision]/$os/[artifact]-[revision].[ext]")
+                            }
+                        }
+                    }
+                    metadataSources { artifact() }
+                }
+            }
+            filter { includeModuleByRegex(".*", ".*kotlin-native-prebuilt.*") }
+        }
     }
-  }
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(
-  ":urlencoder-app",
-  ":urlencoder-lib",
+    ":urlencoder-app",
+    ":urlencoder-lib",
 )


### PR DESCRIPTION
hey @ethauvin 👋 

@krzema12 and I would like to enable more Kotlin Multiplatform targets in https://github.com/krzema12/snakeyaml-engine-kmp, so we can support as many Kotlin targets as possible. snakeyaml-engine-kmp depends on urlencoder, so would you be 

### Summary

* Update Kotlin to 1.9.24 (The Kotlin `languageVersion` is still set to 1.6, so there's no change in the library's ABI)
* Adds additional Kotlin Multiplatform targets
* Tidies the Kotlin Multiplatform source sets, thanks to the [new hierarchy structure](https://kotlinlang.org/docs/multiplatform-hierarchy.html).
* Bumps the Node version used by Kotlin Multiplatform, which is required for Wasm support.
* Refactors urlencoder-app to remove the Java Application plugin (this is no longer compatible with KGP), and instead use KGP's new `mainRun {}` function.

### Testing

I have manually tested the urlencoder-app executable JAR `urlencoder-1.4.0-all.jar`, and it works as expected.

Running the tests for all Kotlin Multiplatform targets requires a Mac with all of the XCode simulators installed.