### PR TITLE
bump version to 1.5.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "net.thauvin.erik.urlencoder"
-version = "1.4.0"
+version = "1.5.0-SNAPSHOT"
 
 dependencies {
     kover(projects.urlencoderLib)


### PR DESCRIPTION
Update the UrlEncoder version to be 1.5.0-SNAPSHOT. It looks like it wasn't updated after the 1.4.0 release.