### PR TITLE
Tidy publishing config

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ jobs:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
@@ -37,17 +37,16 @@ jobs:
           java-version: ${{ matrix.java-version }}
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
 
       - name: Cache Kotlin Konan
-        id: cache-kotlin-konan
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.konan/**/*
           key: kotlin-konan-${{ runner.os }}
 
-      - name: Test with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-home-cache-cleanup: true
-          arguments: build check --stacktrace -PtestsBadgeApiKey=${{ secrets.TESTS_BADGE_API_KEY }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Publish
+        run: ./gradlew check build --stacktrace -PtestsBadgeApiKey=${{ secrets.TESTS_BADGE_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,32 +9,36 @@ env:
   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGN_SECRET_KEY }}
   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGN_SECRET_PWD }}
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  # Don't cancel midway through publishing if another workflow is triggered, it might cause partial publications
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: macos-latest
-    env:
-      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: "11"
           distribution: "zulu"
-          cache: "gradle"
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v2
 
       - name: Cache Kotlin Konan
-        id: cache-kotlin-konan
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.konan/**/*
           key: kotlin-konan-${{ runner.os }}
 
-      - name: Build
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Publish
         run: ./gradlew publish --no-parallel --stacktrace

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/publishing.gradle.kts
@@ -87,10 +87,6 @@ tasks {
         val signingRequiredPredicate = provider { signing.isRequired }
         onlyIf { signingRequiredPredicate.get() }
     }
-
-    withType<GenerateMavenPom> {
-        destination = file("$projectDir/pom.xml")
-    }
 }
 
 // https://youtrack.jetbrains.com/issue/KT-46466


### PR DESCRIPTION
- remove custom POM location (otherwise Gradle gets confused)
- update GitHub actions versions
- use new `gradle/actions/setup-gradle`
- block cancel-in-progress for publish.yml